### PR TITLE
fix for gtk+ 3.14 and above, GtkAlignment was deprecated

### DIFF
--- a/gtkimcontexthangul.c
+++ b/gtkimcontexthangul.c
@@ -1616,7 +1616,10 @@ static GtkWidget*
 status_window_new(GtkWidget *parent)
 {
     GtkWidget *window;
+#if GTK_CHECK_VERSION(3, 14, 0)
+#else
     GtkWidget *alignment;
+#endif
     GtkWidget *label;
     GtkStyleContext* style_context;
     GtkBorder padding;
@@ -1640,16 +1643,30 @@ status_window_new(GtkWidget *parent)
     gtk_style_context_get_padding (style_context, 0, &padding);
     gtk_style_context_get_border (style_context, 0, &border);
 
+#if GTK_CHECK_VERSION(3, 14, 0)
+    gtk_widget_set_halign(window, GTK_ALIGN_CENTER);
+    gtk_widget_set_valign(window, GTK_ALIGN_CENTER);
+    gtk_widget_set_margin_top(window, (gint)(border.top + padding.top));
+    gtk_widget_set_margin_bottom(window, (gint)(border.bottom + padding.bottom));
+    gtk_widget_set_margin_start(window, (gint)(border.left + padding.left));
+    gtk_widget_set_margin_end(window, (gint)(border.right + padding.right));
+    gtk_container_add (GTK_CONTAINER(window), window);
+#else
     alignment = gtk_alignment_new (0.5, 0.5, 1.0, 1.0);
     gtk_alignment_set_padding (GTK_ALIGNMENT(alignment),
 	    border.top + padding.top, border.bottom + padding.bottom,
 	    border.left + padding.left, border.right + padding.right);
     gtk_container_add (GTK_CONTAINER(window), alignment);
     gtk_widget_show (alignment);
+#endif
 
     /* hangul status window label */
     label = gtk_label_new (_("hangul"));
+#if GTK_CHECK_VERSION(3, 14, 0)
+    gtk_container_add (GTK_CONTAINER(window), label);
+#else
     gtk_container_add (GTK_CONTAINER(alignment), label);
+#endif
     gtk_widget_show (label);
 
     g_signal_connect (G_OBJECT(window), "draw",


### PR DESCRIPTION
Hi, 

I am the maintainer for i18n in openSUSE, sorry to send a pull request directly without opening an issue first (I didn't get the issue page unluckily)...

Please review this patch (I am not Korean so I don't even know how to enable imhangul and test), but according to GNOME's developer resources, I think there's little problem in the code itself (I'm a ruby coder myself, not familiar with C either). It fixed the build of imhangul on openSUSE Leap 42.1, 42.2, 42.3 and Tumbleweed.

Any feedback is welcome. Hope I can get it merged upstream with your help

Thanks!

Marguerite